### PR TITLE
hotfix: 화면 상태 관리 로직 변경

### DIFF
--- a/core/base/src/main/java/com/sun5066/base/mvi/BaseViewModel.kt
+++ b/core/base/src/main/java/com/sun5066/base/mvi/BaseViewModel.kt
@@ -1,26 +1,26 @@
 package com.sun5066.base.mvi
 
-import android.os.Parcelable
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.sun5066.config.Constants
 import com.sun5066.config.exception.RequireErrorHandleException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 interface SideEffect
 
-abstract class BaseViewModel<INTENT : Any, STATE : Parcelable, SIDE_EFFECT : SideEffect>(
-    initialState: STATE,
-    private val savedStateHandle: SavedStateHandle
+abstract class BaseViewModel<INTENT : Any, STATE, SIDE_EFFECT : SideEffect>(
+    initialState: STATE
 ) : ViewModel() {
 
-    val state = savedStateHandle.getStateFlow(Constants.MVI_VIEW_MODEL_STATE_KEY, initialState)
+    private val _state = MutableStateFlow(initialState)
+    val state = _state.asStateFlow()
 
     private val currentState: STATE get() = state.value
 
@@ -42,7 +42,7 @@ abstract class BaseViewModel<INTENT : Any, STATE : Parcelable, SIDE_EFFECT : Sid
     ): Job
 
     protected fun updateState(reducer: STATE.() -> STATE) {
-        savedStateHandle[Constants.MVI_VIEW_MODEL_STATE_KEY] = reducer(currentState)
+        _state.update(reducer)
     }
 
     protected fun postSideEffect(sideEffect: SIDE_EFFECT) {

--- a/core/base/src/main/java/com/sun5066/base/mvi/CommonViewModel.kt
+++ b/core/base/src/main/java/com/sun5066/base/mvi/CommonViewModel.kt
@@ -2,7 +2,6 @@ package com.sun5066.base.mvi
 
 import android.os.Parcelable
 import androidx.annotation.StringRes
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.sun5066.base.R
 import com.sun5066.config.Constants
@@ -18,9 +17,8 @@ sealed interface CommonSideEffect : SideEffect {
 }
 
 abstract class CommonViewModel<INTENT : Any, STATE : Parcelable>(
-    initialState: STATE,
-    savedStateHandle: SavedStateHandle
-) : BaseViewModel<INTENT, STATE, CommonSideEffect>(initialState, savedStateHandle) {
+    initialState: STATE
+) : BaseViewModel<INTENT, STATE, CommonSideEffect>(initialState) {
 
     private fun apiExceptionHandle(responseCode: Int) {
         when (responseCode) {

--- a/core/config/src/main/java/com/sun5066/config/Constants.kt
+++ b/core/config/src/main/java/com/sun5066/config/Constants.kt
@@ -14,6 +14,4 @@ object Constants {
     const val RESPONSE_CODE_SERVICE_UNAVAILABLE = 503
 
     const val INJECT_NAMED_RIOT_TOKEN = "riot_token"
-
-    const val MVI_VIEW_MODEL_STATE_KEY = "mvi_state"
 }

--- a/presentation/src/main/java/com/sun5066/presentation/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/sun5066/presentation/main/MainViewModel.kt
@@ -1,6 +1,5 @@
 package com.sun5066.presentation.main
 
-import androidx.lifecycle.SavedStateHandle
 import com.sun5066.base.mvi.CommonViewModel
 import com.sun5066.domain.usecase.GetAccountUseCase
 import com.sun5066.presentation.main.ui.model.mapper.AccountDtoToVoMapper
@@ -12,9 +11,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val getAccountUseCase: GetAccountUseCase,
-    private val accountDtoToVoMapper: AccountDtoToVoMapper,
-    savedStateHandle: SavedStateHandle
-) : CommonViewModel<MainIntent, MainState>(MainState.Init, savedStateHandle) {
+    private val accountDtoToVoMapper: AccountDtoToVoMapper
+) : CommonViewModel<MainIntent, MainState>(MainState.Init) {
 
     override fun processIntent(intent: MainIntent) {
         when (intent) {


### PR DESCRIPTION
기존 SavedStateHandle를 통한, 화면의 상태 저장 및 관리 로직이 Bundle 용량 한계로 인해 MutableStateFlow로 변경